### PR TITLE
Switch to pandas-datareader for stock data

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 streamlit==1.28.0
 pandas==1.5.3
 numpy==1.23.5
-yfinance==0.2.33
 altair==5.1.2
+pandas-datareader==0.10.0


### PR DESCRIPTION
## Summary
- replace `yfinance` with `pandas-datareader` for fetching market data
- add `pandas-datareader` dependency
- remove `yfinance` from requirements

## Testing
- `python -m py_compile main.py`

------
https://chatgpt.com/codex/tasks/task_e_68455ab7a9d48331af1b2acb9f9e54e7