### PR TITLE
Fix Date column rename after reset

### DIFF
--- a/main.py
+++ b/main.py
@@ -96,6 +96,7 @@ st.dataframe(data.style.highlight_max(axis=1))
 data = data[data.columns[::-1]]
 
 data = data.T.reset_index()
+data = data.rename(columns={'index': 'Date'})
 data = pd.melt(data,id_vars=['Date']).rename(
     columns={'value':'Prices(JPN)'}
 )


### PR DESCRIPTION
## Summary
- prevent index column mismatch when melting data

## Testing
- `python -m py_compile main.py`


------
https://chatgpt.com/codex/tasks/task_e_68456126b4c083319511423b458a9341